### PR TITLE
ERA 5 climate download

### DIFF
--- a/programs/3_Process_Summarize_ERA5.Rmd
+++ b/programs/3_Process_Summarize_ERA5.Rmd
@@ -22,11 +22,11 @@ drive_auth()
 
 # Purpose
 
-This script creates 3, 5, 7 day summaries of the Copernicus ERA5 data for Yojoa for use in the downstream Secchi modeling efforts. The ERA5 data were aqcuired in Google Earth Engine using the script `era5_download.js`.
+This script creates 3, 5, 7 day summaries of the Copernicus ERA5 daily data for Yojoa for use in the downstream Secchi modeling efforts. The ERA5 data were aqcuired in Google Earth Engine using the script `era5_download.js`.
 
 ### Suggested Citations:
 
--   Muñoz Sabater, J., (2019): ERA5-Land monthly averaged data from 1981 to present. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (2023-03-30), [doi:10.24381/cds.68d2bb30](https://doi.org/10.24381/cds.68d2bb30)
+-   Muñoz Sabater, J., (2019): ERA5-Land daily averaged data from 1981 to present. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (2023-03-30), [doi:10.24381/cds.68d2bb30](https://doi.org/10.24381/cds.68d2bb30)
 
 # Download and Save Locally
 
@@ -35,7 +35,7 @@ GEE output are saved in Google Drive, first, let's move the ERA5 data to a local
 ```{r}
 #get did -- note, if you have a lot of files in your drive, you may want to define the folder before you search for the file.
 dr_file = drive_ls(pattern = 'yojoa_era5_data.csv')
-drive_download(as_id(dr_file$id), path = file.path(era_dir, dr_file$name))
+drive_download(as_id(dr_file$id), path = file.path(era_dir, dr_file$name), overwrite = T)
 ```
 
 # Make summary files
@@ -60,9 +60,9 @@ era5$wind_speed_mps = sqrt(era5$u_component_of_wind_10m^2 + era5$v_component_of_
 ```{r}
 era5_sub = era5 %>% 
   select(date, 
-         precip_m = total_precipitation,
-         max_air_temp_degK = maximum_2m_air_temperature,
-         min_air_temp_degK = minimum_2m_air_temperature,
+         solar_rad_Jpm2 = surface_solar_radiation_downwards_sum,
+         precip_m = total_precipitation_sum,
+         air_temp_degK = temperature_2m,
          wind_speed_mps)
 ```
 
@@ -73,8 +73,8 @@ Previous 3 days summary
 ```{r}
 threeday = as.data.frame(era5_sub$date[3:nrow(era5_sub)])
 colnames(threeday) = 'date'
-threeday$max_temp_degK_3 = roll_max(x  = era5_sub$max_air_temp_degK, align = 'right', 3)
-threeday$min_temp_degK_3 = roll_min(x  = era5_sub$min_air_temp_degK, align = 'right', 3)
+threeday$tot_sol_rad_KJpm2_3 = roll_sum(x = era5_sub$solar_rad_Jpm2, align = 'right', 3)*0.001
+threeday$mean_temp_degK_3 = roll_mean(x  = era5_sub$air_temp_degK, align = 'right', 3)
 threeday$tot_precip_m_3 = roll_sum(x  = era5_sub$precip_m, align = 'right', 3)
 threeday$mean_wind_mps_3 = roll_mean(x  = era5_sub$wind_speed_mps, align = 'right', 3)
 ```
@@ -84,8 +84,8 @@ Previous 5 days summary
 ```{r}
 fiveday = as.data.frame(era5_sub$date[5:nrow(era5_sub)])
 colnames(fiveday) = 'date'
-fiveday$max_temp_degK_5 = roll_max(x  = era5_sub$max_air_temp_degK, align = 'right', 5)
-fiveday$min_temp_degK_5 = roll_min(x  = era5_sub$min_air_temp_degK, align = 'right', 5)
+fiveday$tot_sol_rad_KJpm2_5 = roll_sum(x = era5_sub$solar_rad_Jpm2, align = 'right', 5)*0.001
+fiveday$mean_temp_degK_5 = roll_mean(x  = era5_sub$air_temp_degK, align = 'right', 5)
 fiveday$tot_precip_m_5 = roll_sum(x  = era5_sub$precip_m, align = 'right', 5)
 fiveday$mean_wind_mps_5 = roll_mean(x  = era5_sub$wind_speed_mps, align = 'right', 5)
 ```
@@ -95,8 +95,8 @@ Seven-day summary
 ```{r}
 sevenday = as.data.frame(era5_sub$date[7:nrow(era5_sub)])
 colnames(sevenday) = 'date'
-sevenday$max_temp_degK_7 = roll_max(x  = era5_sub$max_air_temp_degK, align = 'right', 7)
-sevenday$min_temp_degK_7 = roll_min(x  = era5_sub$min_air_temp_degK, align = 'right', 7)
+sevenday$tot_sol_rad_KJpm2_7 = roll_sum(x = era5_sub$solar_rad_Jpm2, align = 'right', 7)*0.001
+sevenday$mean_temp_degK_7 = roll_mean(x  = era5_sub$air_temp_degK, align = 'right', 7)
 sevenday$tot_precip_m_7 = roll_sum(x  = era5_sub$precip_m, align = 'right', 7)
 sevenday$mean_wind_mps_7 = roll_mean(x  = era5_sub$wind_speed_mps, align = 'right', 7)
 ```

--- a/programs/3_Process_Summarize_ERA5.Rmd
+++ b/programs/3_Process_Summarize_ERA5.Rmd
@@ -26,7 +26,7 @@ This script creates 3, 5, 7 day summaries of the Copernicus ERA5 data for Yojoa 
 
 ### Suggested Citations:
 
--   Copernicus Climate Change Service (C3S) (2017): ERA5: Fifth generation of ECMWF atmospheric reanalyses of the global climate. Copernicus Climate Change Service Climate Data Store (CDS), (2023-03-29), <https://cds.climate.copernicus.eu/cdsapp#!/home>
+-   Muñoz Sabater, J., (2019): ERA5-Land monthly averaged data from 1981 to present. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). (2023-03-30), [doi:10.24381/cds.68d2bb30](https://doi.org/10.24381/cds.68d2bb30)
 
 # Download and Save Locally
 

--- a/programs/3_Process_Summarize_ERA5.Rmd
+++ b/programs/3_Process_Summarize_ERA5.Rmd
@@ -1,0 +1,114 @@
+---
+title: "Process and Summarize ERA5 data"
+author: "B Steele"
+date: "2023-03-30"
+output: html_document
+---
+
+```{r}
+library(tidyverse)
+library(ggthemes)
+library(RcppRoll)
+library(googledrive)
+
+#point to directories
+drv_dir = 'data/fromDrive/'
+era_dir = 'data/era5_met/'
+
+#authenticate drive
+drive_auth()
+1 #this will select the first account option in google drive
+```
+
+# Purpose
+
+This script creates 3, 5, 7 day summaries of the Copernicus ERA5 data for Yojoa for use in the downstream Secchi modeling efforts. The ERA5 data were aqcuired in Google Earth Engine using the script `era5_download.js`.
+
+### Suggested Citations:
+
+-   Copernicus Climate Change Service (C3S) (2017): ERA5: Fifth generation of ECMWF atmospheric reanalyses of the global climate. Copernicus Climate Change Service Climate Data Store (CDS), (2023-03-29), <https://cds.climate.copernicus.eu/cdsapp#!/home>
+
+# Download and Save Locally
+
+GEE output are saved in Google Drive, first, let's move the ERA5 data to a local folder to save for posterity.
+
+```{r}
+#get did -- note, if you have a lot of files in your drive, you may want to define the folder before you search for the file.
+dr_file = drive_ls(pattern = 'yojoa_era5_data.csv')
+drive_download(as_id(dr_file$id), path = file.path(era_dir, dr_file$name))
+```
+
+# Make summary files
+
+### Load in ERA5 data and format date
+
+```{r}
+era5 = read.csv(file.path(era_dir, dr_file$name)) %>% 
+  mutate(date = as.Date(substr(system.index, 1, 8), format = '%Y%m%d'))
+```
+
+### Calculate wind speed from u and v components
+
+U and V are zonal and meridional winds characteristics. Wind speed is calculated using the Pythagorean theorem, where wind speed is equal to the square root of the sum of the squares of the u and v characteristics. For more information about this, see [NASA's description and U and V components](https://disc.gsfc.nasa.gov/information/data-in-action?title=Derive%20Wind%20Speed%20and%20Direction%20With%20MERRA-2%20Wind%20Components).
+
+```{r}
+era5$wind_speed_mps = sqrt(era5$u_component_of_wind_10m^2 + era5$v_component_of_wind_10m^2)
+```
+
+### Select the parameters we're interested in and rename them with units
+
+```{r}
+era5_sub = era5 %>% 
+  select(date, 
+         precip_m = total_precipitation,
+         max_air_temp_degK = maximum_2m_air_temperature,
+         min_air_temp_degK = minimum_2m_air_temperature,
+         wind_speed_mps)
+```
+
+### Summarize data in 3,5,7 day summaries
+
+Previous 3 days summary
+
+```{r}
+threeday = as.data.frame(era5_sub$date[3:nrow(era5_sub)])
+colnames(threeday) = 'date'
+threeday$max_temp_degK_3 = roll_max(x  = era5_sub$max_air_temp_degK, align = 'right', 3)
+threeday$min_temp_degK_3 = roll_min(x  = era5_sub$min_air_temp_degK, align = 'right', 3)
+threeday$tot_precip_m_3 = roll_sum(x  = era5_sub$precip_m, align = 'right', 3)
+threeday$mean_wind_mps_3 = roll_mean(x  = era5_sub$wind_speed_mps, align = 'right', 3)
+```
+
+Previous 5 days summary
+
+```{r}
+fiveday = as.data.frame(era5_sub$date[5:nrow(era5_sub)])
+colnames(fiveday) = 'date'
+fiveday$max_temp_degK_5 = roll_max(x  = era5_sub$max_air_temp_degK, align = 'right', 5)
+fiveday$min_temp_degK_5 = roll_min(x  = era5_sub$min_air_temp_degK, align = 'right', 5)
+fiveday$tot_precip_m_5 = roll_sum(x  = era5_sub$precip_m, align = 'right', 5)
+fiveday$mean_wind_mps_5 = roll_mean(x  = era5_sub$wind_speed_mps, align = 'right', 5)
+```
+
+Seven-day summary
+
+```{r}
+sevenday = as.data.frame(era5_sub$date[7:nrow(era5_sub)])
+colnames(sevenday) = 'date'
+sevenday$max_temp_degK_7 = roll_max(x  = era5_sub$max_air_temp_degK, align = 'right', 7)
+sevenday$min_temp_degK_7 = roll_min(x  = era5_sub$min_air_temp_degK, align = 'right', 7)
+sevenday$tot_precip_m_7 = roll_sum(x  = era5_sub$precip_m, align = 'right', 7)
+sevenday$mean_wind_mps_7 = roll_mean(x  = era5_sub$wind_speed_mps, align = 'right', 7)
+```
+
+Join them together and save the file
+
+```{r}
+era5_summary = full_join(threeday, fiveday) %>% full_join(., sevenday)
+```
+
+Save the file for use in modeling efforts
+
+```{r}
+write.csv(era5_summary, file.path(era_dir, 'Yojoa_3-5-7day_summary_ERA5.csv'), row.names = F)
+```

--- a/programs/era5_download.js
+++ b/programs/era5_download.js
@@ -1,11 +1,11 @@
-// ERA5 data download script for yojoa
+// ERA5 data download for Yojoa
 
 var lat = 14.8768;
 var lon = -87.9791;
 
 var loc = ee.Geometry.Point(lon, lat);
 
-var era5 = ee.ImageCollection('ECMWF/ERA5/DAILY')
+var era5 = ee.ImageCollection("ECMWF/ERA5_LAND/DAILY_RAW")
   .filterBounds(loc);
   
 // Sample the image at the point

--- a/programs/era5_download.js
+++ b/programs/era5_download.js
@@ -1,0 +1,28 @@
+// ERA5 data download script for yojoa
+
+var lat = 14.8768;
+var lon = -87.9791;
+
+var loc = ee.Geometry.Point(lon, lat);
+
+var era5 = ee.ImageCollection('ECMWF/ERA5/DAILY')
+  .filterBounds(loc);
+  
+// Sample the image at the point
+function era5_summary(image) {
+  var reduced = image.reduceRegions({
+    reducer: ee.Reducer.mean(),
+    collection: loc,
+    scale: era5.first().projection().nominalScale()
+  });
+  return reduced;
+}
+
+var era5_reduced = era5.map(era5_summary).flatten();
+
+Export.table.toDrive({
+  collection: era5_reduced,
+  description: 'yojoa_era5_data',
+  folder: 'era5',
+  fileFormat: 'CSV'
+});


### PR DESCRIPTION
Hey Katie - this is a follow up to the other pull request. Tagging you in here, because again, this might be helpful in future endeavors for you, and this gives you an idea of what I'm working on!

Some context:
- we need climate drivers to help with the xgboost modeling for Yojoa - a Honduran lake that Jemma/Ed have a ton of Secchi data for. This is partly because we know that wind/temp/precip can all impact Secchi in various way. At this lake temperature is kind of moot, but we'll use it as a stand in for seasonality without supplying the date to a ML model.
- as noted in that other PR in ROSS_RS_mini_tools, the GLDAS data were incomplete (they had holes in weird places that I couldn't fill) -- turns out Simon originally pulled ERA5 precip data for Jemma but who knows where that data lives, so we're just grabbing all the ERA5 data and moving forward from there.
- ERA5 is a satellite and climate model fusion to create seamless climate data at a 0.25degree grid across the world.

Okay, scripts in this PR:
- programs/era5_download.js - this is the GEE script that acquires the ERA5 data for Yojoa - it's pretty straightforward, it just grabs data from a single point for all of the available data in the ERA5 dataset.
- programs/3_Process_Summarize_ERA5.Rmd - this is a spin off of the script in the other PR, where we pull in the ERA5 data and summarize as 3-5-7 days prior to every day available. We will be matching this data up with every satellite acquisition date for training, testing, and application of the ML model. Admittedly there is a much cleaner/sophisticated way to do the 3-5-7 day summaries, but for this application, I just played copy/paste.

Let me know if you have questions! I don't think this review should take terribly long, and a quick review would be most helpful for me/MR and very much appreciated! 

This PR Closes #4 